### PR TITLE
This is a fix for a libusb dereference crash when openhantek\src\sele…

### DIFF
--- a/openhantek/src/usb/usbdevice.cpp
+++ b/openhantek/src/usb/usbdevice.cpp
@@ -99,7 +99,11 @@ bool USBDevice::connectDevice(QString &errorMessage) {
     return true;
 }
 
-USBDevice::~USBDevice() { disconnectFromDevice(); }
+USBDevice::~USBDevice() { 
+	disconnectFromDevice(); 
+	if (device != nullptr) libusb_unref_device(device);
+	device = nullptr;
+}
 
 int USBDevice::claimInterface(const libusb_interface_descriptor *interfaceDescriptor, int endpointOut, int endPointIn) {
     int errorCode = libusb_claim_interface(this->handle, interfaceDescriptor->bInterfaceNumber);
@@ -134,8 +138,6 @@ void USBDevice::disconnectFromDevice() {
         libusb_close(this->handle);
     }
     this->handle = nullptr;
-
-    libusb_unref_device(device);
 
     emit deviceDisconnected();
 }


### PR DESCRIPTION
…cteddevice\deviceslistmodel.cpp function: DevicesListModel::updateDeviceList() calls the disconnectFromDevice() function on line 76. The disconnect function unrefs the device. There must be an additional ref added by connecting in *nix/osx that isn't added in windows, possibly to the handle. Or during disconnect things are being deconstructed wrong and in nix this is resulting in an extra ref to the libusb device pointer. This is a windows only fix AFAIK, it may work on *nix and osx, it may not. Since this is against theilj's repository I am adding a pull request to get windows builds working. The real fix probably lies within a difference within the *nix and windows libusb code.  I fixed this by doing the unref in the destructor, since the device is originally referenced in the constructor anyways, it seems like it is meant to live as long as the usbdevice class, especially since it is passed out of the functionality that constructed it.